### PR TITLE
footer neople link

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,11 +14,7 @@ export default function Footer() {
     >
       <Box fontSize="sm">© DUNLINE. All rights reserved.</Box>
       <Box position="relative" width="190px" height="18px">
-        <Link
-          href="https://open.kakao.com/o/s3Dh8Afe"
-          passHref
-          prefetch={false}
-        >
+        <Link href="https://developers.neople.co.kr/" passHref prefetch={false}>
           <a>
             <Image
               src="/images/footer_neople/footer_neople@2x.png"


### PR DESCRIPTION
footer에서 

던파 api관련 이미지클릭시 카톡문의하기로 이동하던 버그 수정
-> https://developers.neople.co.kr/ 로 이동